### PR TITLE
Revoke identity token from API

### DIFF
--- a/fabric_cm/__init__.py
+++ b/fabric_cm/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 __API_REFERENCE__ = "https://github.com/fabric-testbed/CredentialManager"

--- a/fabric_cm/credmgr/common/utils.py
+++ b/fabric_cm/credmgr/common/utils.py
@@ -79,15 +79,17 @@ class Utils:
         return cookie_or_exception
 
     @staticmethod
-    def is_facility_operator(*, cookie: str):
+    def is_facility_operator(*, cookie: str, token: str = None):
         """
         Validate if user with provided vouch cookie a facility operator
         @param cookie cookie
+        @param token token
         @return True if user is FP; False otherwise
         """
         core_api = CoreApi(api_server=CONFIG_OBJ.get_core_api_url(), cookie=cookie,
                            cookie_name=CONFIG_OBJ.get_vouch_cookie_name(),
-                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name())
+                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name(),
+                           token=token)
         uuid, email = core_api.get_user_id_and_email()
         roles = core_api.get_user_roles(uuid=uuid)
 

--- a/fabric_cm/credmgr/core/oauth_credmgr.py
+++ b/fabric_cm/credmgr/core/oauth_credmgr.py
@@ -371,7 +371,8 @@ class OAuthCredMgr:
         if response.status_code != 200:
             raise OAuthCredMgrError("Refresh token could not be revoked!")
 
-    def revoke_identity_token(self, token_hash: str, cookie: str, user_email: str = None, project_id: str = None):
+    def revoke_identity_token(self, token_hash: str, cookie: str, user_email: str = None, project_id: str = None,
+                              token: str = None):
         """
          Revoke a fabric identity token
 
@@ -381,6 +382,8 @@ class OAuthCredMgr:
          :type user_email: str
          :param cookie: Cookie
          :type cookie: str
+         :param token: Token
+         :type token: str
 
          @returns dictionary containing status of the operation
          @raises Exception in case of error
@@ -389,7 +392,7 @@ class OAuthCredMgr:
             raise OAuthCredMgrError(f"User Id/Email or Token Hash required")
 
         # Facility Operator query all tokens
-        if Utils.is_facility_operator(cookie=cookie):
+        if Utils.is_facility_operator(cookie=cookie, token=token):
             tokens = self.get_tokens(token_hash=token_hash)
         # Otherwise query only this user's tokens
         else:

--- a/fabric_cm/credmgr/external_apis/core_api.py
+++ b/fabric_cm/credmgr/external_apis/core_api.py
@@ -35,31 +35,39 @@ class CoreApi:
     """
     Class implements functionality to interface with Project Registry
     """
-    def __init__(self, api_server: str, cookie: str, cookie_name: str, cookie_domain: str):
+    def __init__(self, api_server: str, cookie: str, cookie_name: str, cookie_domain: str, token: str = None):
         self.api_server = api_server
         self.cookie = cookie
         self.cookie_name = cookie_name
         self.cookie_domain = cookie_domain
+        self.token = token
 
-        if self.api_server is None or self.cookie is None:
-            raise CoreApiError(f"Core URL: {self.api_server} or Cookie: {self.cookie} not available")
+        if self.api_server is None:
+            raise CoreApiError(f"Core URL: {self.api_server} not available")
 
-        # Create Session
-        self.session = requests.Session()
-
-        # Set the Cookie
-        cookie_obj = requests.cookies.create_cookie(
-            name=self.cookie_name,
-            value=self.cookie
-        )
-        self.session.cookies.set_cookie(cookie_obj)
-        LOG.debug(f"Using vouch cookie: {self.session.cookies}")
+        if self.cookie is None and self.token is None:
+            raise CoreApiError(f"Either cookie or token must be specified!")
 
         # Set the headers
         headers = {
             'Accept': 'application/json',
             'Content-Type': "application/json"
         }
+
+        # Create Session
+        self.session = requests.Session()
+
+        if cookie is not None:
+            # Set the Cookie
+            cookie_obj = requests.cookies.create_cookie(
+                name=self.cookie_name,
+                value=self.cookie
+            )
+            self.session.cookies.set_cookie(cookie_obj)
+            LOG.debug(f"Using vouch cookie: {self.session.cookies}")
+        else:
+            headers['authorization'] = f"Bearer {token}"
+
         self.session.headers.update(headers)
 
     def get_user_id_and_email(self) -> Tuple[str, str]:

--- a/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
+++ b/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
@@ -249,12 +249,10 @@ def tokens_revokes_post(body: TokenPost, claims: dict = None):  # noqa: E501
         credmgr = OAuthCredMgr()
         if body.type == "identity":
             cookie = claims.get(OAuthCredMgr.COOKIE)
-            # Build the cookie
-            if cookie is None:
-                id_token = request.headers.get('authorization')
-                id_token = id_token.replace('Bearer ', '')
+            id_token = request.headers.get('authorization')
+            id_token = id_token.replace('Bearer ', '')
             credmgr.revoke_identity_token(token_hash=body.token, user_email=claims.get(OAuthCredMgr.EMAIL),
-                                          cookie=cookie)
+                                          cookie=cookie, token=id_token)
         else:
             credmgr.revoke_token(refresh_token=body.token)
         success_counter.labels(HTTP_METHOD_POST, TOKENS_REVOKES_URL).inc()

--- a/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
+++ b/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
@@ -27,6 +27,7 @@ from datetime import datetime
 import connexion
 from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 
+from fabric_cm.credmgr.common.utils import Utils
 from fabric_cm.credmgr.core.oauth_credmgr import OAuthCredMgr, TokenState
 from fabric_cm.credmgr.swagger_server.models import Tokens, Token, Status200OkNoContent, Status200OkNoContentData, \
     RevokeList, DecodedToken
@@ -39,7 +40,7 @@ from fabric_cm.credmgr.swagger_server.response.constants import HTTP_METHOD_POST
 from fabric_cm.credmgr.logging import LOG
 from fabric_cm.credmgr.swagger_server.response.cors_response import cors_200, cors_500, cors_400
 from fabric_cm.credmgr.swagger_server.response.decorators import login_required, login_or_token_required
-
+from flask import request
 
 @login_required
 def tokens_create_post(project_id: str, project_name: str, scope: str = None, lifetime: int = 4, comment: str = None,
@@ -247,8 +248,13 @@ def tokens_revokes_post(body: TokenPost, claims: dict = None):  # noqa: E501
     try:
         credmgr = OAuthCredMgr()
         if body.type == "identity":
+            cookie = claims.get(OAuthCredMgr.COOKIE)
+            # Build the cookie
+            if cookie is None:
+                id_token = request.headers.get('authorization')
+                id_token = id_token.replace('Bearer ', '')
             credmgr.revoke_identity_token(token_hash=body.token, user_email=claims.get(OAuthCredMgr.EMAIL),
-                                          cookie=claims.get(OAuthCredMgr.COOKIE))
+                                          cookie=cookie)
         else:
             credmgr.revoke_token(refresh_token=body.token)
         success_counter.labels(HTTP_METHOD_POST, TOKENS_REVOKES_URL).inc()


### PR DESCRIPTION
Revoke identity token always expected cookie to be present which is not the case when doing revoke via python code or cli.
Updated the code to use the token to authorize against core api when cookie is not available