### PR TITLE
Compress token before encode

### DIFF
--- a/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
+++ b/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
@@ -508,6 +508,7 @@ def tokens_create_cli_get(project_id: str = None, project_name: str = None, scop
         # Use sanitized components (safe_scheme, safe_netloc, safe_path) instead of
         # raw redirect_uri to avoid untrusted URL redirection (CodeQL security finding)
         import base64 as _base64
+        import zlib as _zlib
         params = {
             "id_token": token_dict.get("id_token", ""),
             "refresh_token": token_dict.get("refresh_token", ""),
@@ -523,7 +524,7 @@ def tokens_create_cli_get(project_id: str = None, project_name: str = None, scop
 
         # Build a base64-encoded authorization code for manual paste fallback
         auth_code = _base64.urlsafe_b64encode(
-            _json.dumps(params).encode()
+            _zlib.compress(_json.dumps(params).encode(), 9)
         ).decode()
 
         LOG.info("CLI token created, serving delivery page")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "six",
     "cryptography",
     "authlib",
-    "fabric_fss_utils==1.6.1",
+    "fabric_fss_utils",
     "psycopg2-binary",
     "sqlalchemy",
     ]


### PR DESCRIPTION
Authorization code for token for projects which hav all permissions enabled is too long, so enabled compression