### PR TITLE
Fix credential display for normal users on Storage page

### DIFF
--- a/cm-app/src/app/storage/page.tsx
+++ b/cm-app/src/app/storage/page.tsx
@@ -1037,13 +1037,7 @@ export default function StoragePage() {
       // Export keyring
       try {
         const { data: response } = await exportUserKeyrings(token, selectedCluster, [entity]);
-        const keyring = typeof response === "string"
-          ? response
-          : response.data
-            ? typeof response.data === "string"
-              ? response.data
-              : JSON.stringify(response.data, null, 2)
-            : "";
+        const keyring = extractKeyring(response, entity);
         setMyKeyring(keyring);
       } catch {
         setMyKeyring("");

--- a/cm-app/src/app/storage/page.tsx
+++ b/cm-app/src/app/storage/page.tsx
@@ -969,13 +969,8 @@ export default function StoragePage() {
     if (clustersMap?.[selectedCluster]?.[entity]) {
       return clustersMap[selectedCluster][entity];
     }
-    // Fallback: response.data could be a string or object
-    if (typeof response === "string") return response;
-    if (response.data) {
-      if (typeof response.data === "string") return response.data;
-      return JSON.stringify(response.data, null, 2);
-    }
-    return JSON.stringify(response, null, 2);
+    // No keyring found for this entity on this cluster
+    return "";
   };
 
   const handleExportKeyring = async (entity: string) => {
@@ -1030,6 +1025,7 @@ export default function StoragePage() {
 
   const loadMyCredentials = useCallback(async () => {
     if (!bastionLogin || !selectedCluster) return;
+    setMyKeyring("");
     try {
       const token = await ensureToken();
       const entity = `client.${bastionLogin}`;


### PR DESCRIPTION
## Summary
- Fix normal user view showing 'No CephFS keyring found' even when credentials exist
- Reuse existing extractKeyring() helper instead of broken inline parsing that checked response.data instead of response.clusters
- Clear stale keyring when switching clusters so old credentials do not persist in the UI
- Return empty string from extractKeyring() when no keyring exists instead of dumping raw JSON

## Test plan
- [x] Log in as normal user with credentials on one cluster (e.g. east) - verify keyring is displayed
- [x] Switch to a cluster with no credentials (e.g. europe) - verify 'No CephFS keyring found' message appears
- [x] Switch back to the cluster with credentials - verify keyring reappears
- [x] Log in as operator - verify export keyring still works correctly