### PR TITLE
Cookie chunking and member_of stripping for vouch cookies

### DIFF
--- a/fabric_cm/credmgr/common/utils.py
+++ b/fabric_cm/credmgr/common/utils.py
@@ -22,6 +22,9 @@
 # SOFTWARE.
 #
 # Author Komal Thareja (kthare10@renci.org)
+import base64
+import json
+
 from fabric_cm.credmgr.external_apis.core_api import CoreApi
 
 from fabric_cm.credmgr.logging import LOG
@@ -67,7 +70,15 @@ class Utils:
             if c_type == CustomClaimsType.CILOGON_USER_INFO.name:
                 custom_claims.append(CustomClaimsType.CILOGON_USER_INFO)
 
-        p_tokens = PTokens(id_token=id_token, idp_claims=claims)
+        # Remove member_of from claims and id_token to reduce cookie size
+        filtered_claims = {k: v for k, v in claims.items() if k != "member_of"}
+
+        # Strip member_of from the JWT payload to shrink PIdToken in the cookie.
+        # The vouch cookie itself is integrity-protected, so the modified JWT
+        # does not need a valid CILogon signature inside the cookie.
+        stripped_id_token = Utils._strip_jwt_claim(id_token, "member_of")
+
+        p_tokens = PTokens(id_token=stripped_id_token, idp_claims=filtered_claims)
 
         code, cookie_or_exception = vouch_helper.encode(custom_claims_type=custom_claims, p_tokens=p_tokens,
                                                         validity_in_seconds=vouch_cookie_lifetime)
@@ -77,6 +88,33 @@ class Utils:
             raise cookie_or_exception
 
         return cookie_or_exception
+
+    @staticmethod
+    def _strip_jwt_claim(token: str, claim: str) -> str:
+        """
+        Remove a claim from a JWT payload and return the modified JWT.
+        The signature becomes invalid, but this is acceptable when the JWT
+        is embedded inside an integrity-protected vouch cookie.
+        """
+        try:
+            parts = token.split('.')
+            if len(parts) != 3:
+                return token
+            # Decode payload (add padding as needed)
+            payload_b64 = parts[1]
+            payload_b64 += '=' * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+            if claim not in payload:
+                return token
+            del payload[claim]
+            # Re-encode payload (strip padding to match JWT format)
+            new_payload_b64 = base64.urlsafe_b64encode(
+                json.dumps(payload, separators=(',', ':')).encode()
+            ).rstrip(b'=').decode()
+            return f"{parts[0]}.{new_payload_b64}.{parts[2]}"
+        except Exception:
+            LOG.warning(f"Failed to strip '{claim}' from JWT, using original token")
+            return token
 
     @staticmethod
     def is_facility_operator(*, cookie: str, token: str = None):

--- a/fabric_cm/credmgr/core/oauth_credmgr.py
+++ b/fabric_cm/credmgr/core/oauth_credmgr.py
@@ -577,6 +577,33 @@ class OAuthCredMgr:
         # Ensure user exists in LLM proxy and is part of the team
         self._ensure_llm_user_and_team(llm_api, uuid, email)
 
+        # Enforce max active LLM keys per user (limit: 10)
+        max_llm_keys = 10
+        try:
+            existing_keys = llm_api.list_keys(user_id=uuid)
+            # Filter out expired keys
+            from datetime import datetime, timezone
+            now = datetime.now(timezone.utc)
+            active_count = 0
+            for k in existing_keys:
+                expires_str = k.get('expires')
+                if expires_str:
+                    try:
+                        expires_dt = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
+                        if expires_dt < now:
+                            continue
+                    except (ValueError, TypeError):
+                        pass
+                active_count += 1
+            if active_count >= max_llm_keys:
+                raise OAuthCredMgrError(
+                    f"User {email} already has {active_count} active LLM keys "
+                    f"(maximum {max_llm_keys}). Please delete unused keys first.")
+        except OAuthCredMgrError:
+            raise
+        except Exception as ex:
+            LOG.warning(f"Could not check existing LLM key count for {uuid}: {ex}")
+
         max_duration = int(CONFIG_OBJ.get_llm_default_duration().rstrip('d'))
         if duration_days is None or duration_days < 1:
             duration_days = max_duration
@@ -628,12 +655,13 @@ class OAuthCredMgr:
             'comment': comment
         }
 
-    def delete_llm_key(self, llm_key_id: str, user_email: str, cookie: str):
+    def delete_llm_key(self, llm_key_id: str, user_email: str, cookie: str = None, token: str = None):
         """
         Delete an LLM API key
         @param llm_key_id LLM key identifier
         @param user_email User's email
-        @param cookie Vouch cookie
+        @param cookie Vouch cookie (browser auth)
+        @param token FABRIC id_token (Bearer auth — alternative to cookie)
         """
         llm_api = LiteLLMApi(api_server=CONFIG_OBJ.get_llm_url(),
                                  master_key=CONFIG_OBJ.get_llm_api_key())
@@ -650,7 +678,8 @@ class OAuthCredMgr:
         from fabric_cm.credmgr.external_apis.core_api import CoreApi
         core_api = CoreApi(api_server=CONFIG_OBJ.get_core_api_url(), cookie=cookie,
                            cookie_name=CONFIG_OBJ.get_vouch_cookie_name(),
-                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name())
+                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name(),
+                           token=token)
         uuid, email = core_api.get_user_id_and_email()
 
         if key_owner != uuid:
@@ -669,11 +698,12 @@ class OAuthCredMgr:
                   project_id=CONFIG_OBJ.get_llm_allowed_project(),
                   user_id=uuid, user_email=email)
 
-    def get_llm_keys(self, cookie: str, offset: int = 0, limit: int = 200) -> list:
+    def get_llm_keys(self, cookie: str = None, token: str = None, offset: int = 0, limit: int = 200) -> list:
         """
         Get LLM keys for a user by querying LLM proxy API directly.
         Expired keys are automatically deleted before returning the list.
         @param cookie Vouch cookie
+        @param token Bearer token (alternative to cookie)
         @param offset offset
         @param limit limit
         @return list of active (non-expired) LLM key records
@@ -681,7 +711,8 @@ class OAuthCredMgr:
         from fabric_cm.credmgr.external_apis.core_api import CoreApi
         core_api = CoreApi(api_server=CONFIG_OBJ.get_core_api_url(), cookie=cookie,
                            cookie_name=CONFIG_OBJ.get_vouch_cookie_name(),
-                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name())
+                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name(),
+                           token=token)
         uuid, email = core_api.get_user_id_and_email()
 
         llm_api = LiteLLMApi(api_server=CONFIG_OBJ.get_llm_url(),

--- a/fabric_cm/credmgr/core/oauth_credmgr.py
+++ b/fabric_cm/credmgr/core/oauth_credmgr.py
@@ -531,12 +531,13 @@ class OAuthCredMgr:
         except LiteLLMApiError as e:
             LOG.warning(f"Could not add user {uuid} to team {team_id}: {e}")
 
-    def create_llm_key(self, cookie: str, key_name: str = None, comment: str = None,
-                       duration_days: int = 30, models: list = None) -> dict:
+    def create_llm_key(self, cookie: str = None, token: str = None, key_name: str = None,
+                       comment: str = None, duration_days: int = 30, models: list = None) -> dict:
         """
         Create an LLM API key for the user.
         Full workflow: verify FABRIC project membership → ensure LLM user → add to team → generate key.
-        @param cookie Vouch cookie
+        @param cookie Vouch cookie (browser auth)
+        @param token FABRIC id_token (Bearer auth — alternative to cookie)
         @param key_name Human-readable name for the key
         @param comment Comment
         @param duration_days Token duration in days (1-30)
@@ -546,7 +547,8 @@ class OAuthCredMgr:
 
         core_api = CoreApi(api_server=CONFIG_OBJ.get_core_api_url(), cookie=cookie,
                            cookie_name=CONFIG_OBJ.get_vouch_cookie_name(),
-                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name())
+                           cookie_domain=CONFIG_OBJ.get_vouch_cookie_domain_name(),
+                           token=token)
 
         uuid, email = core_api.get_user_id_and_email()
 

--- a/fabric_cm/credmgr/core/oauth_credmgr.py
+++ b/fabric_cm/credmgr/core/oauth_credmgr.py
@@ -166,8 +166,16 @@ class OAuthCredMgr:
 
         # validate the token
         if jwt_validator is not None:
-            LOG.info("Validating CI Logon token")
-            code, claims_or_exception = jwt_validator.validate_jwt(token=ci_logon_id_token)
+            if cookie is not None:
+                # Token comes from our vouch cookie where member_of was stripped,
+                # breaking the CILogon signature. The vouch cookie itself is
+                # integrity-protected, so decode without signature verification.
+                LOG.info("Decoding CI Logon token from cookie (signature not verified)")
+                claims_or_exception = jwt.decode(ci_logon_id_token, options={"verify_signature": False})
+                code = ValidateCode.VALID
+            else:
+                LOG.info("Validating CI Logon token")
+                code, claims_or_exception = jwt_validator.validate_jwt(token=ci_logon_id_token)
             if code is not ValidateCode.VALID:
                 LOG.error(f"Unable to validate provided token: {code}/{claims_or_exception}")
                 raise claims_or_exception

--- a/fabric_cm/credmgr/external_apis/core_api.py
+++ b/fabric_cm/credmgr/external_apis/core_api.py
@@ -35,6 +35,7 @@ class CoreApi:
     """
     Class implements functionality to interface with Project Registry
     """
+    VOUCH_COOKIE_CHUNK_SIZE = 4000
 
     @staticmethod
     def _extract_error_message(response) -> str:
@@ -57,6 +58,18 @@ class CoreApi:
             if len(text) > 256:
                 text = text[:256] + "...(truncated)"
             return text
+
+    def _set_chunked_cookie(self, cookie_value: str):
+        """
+        Set a cookie on the session, chunking it the same way vouch-proxy does.
+        Vouch splits cookies > 4000 bytes into <name>, <name>_1, <name>_2, etc.
+        """
+        for i in range(0, len(cookie_value), self.VOUCH_COOKIE_CHUNK_SIZE):
+            chunk = cookie_value[i:i + self.VOUCH_COOKIE_CHUNK_SIZE]
+            chunk_index = i // self.VOUCH_COOKIE_CHUNK_SIZE
+            name = self.cookie_name if chunk_index == 0 else f"{self.cookie_name}_{chunk_index}"
+            cookie_obj = requests.cookies.create_cookie(name=name, value=chunk)
+            self.session.cookies.set_cookie(cookie_obj)
 
     def __init__(self, api_server: str, cookie: str, cookie_name: str, cookie_domain: str, token: str = None):
         self.api_server = api_server
@@ -81,12 +94,8 @@ class CoreApi:
         self.session = requests.Session()
 
         if cookie is not None:
-            # Set the Cookie
-            cookie_obj = requests.cookies.create_cookie(
-                name=self.cookie_name,
-                value=self.cookie
-            )
-            self.session.cookies.set_cookie(cookie_obj)
+            # Chunk cookie the same way vouch-proxy does (splits at 4000 bytes)
+            self._set_chunked_cookie(cookie)
             LOG.debug(f"Using vouch cookie: {self.session.cookies}")
         else:
             headers['authorization'] = f"Bearer {token}"

--- a/fabric_cm/credmgr/swagger_server/response/decorators.py
+++ b/fabric_cm/credmgr/swagger_server/response/decorators.py
@@ -100,19 +100,22 @@ def vouch_authorize() -> Union[dict, None]:
 def validate_authorization_token(token: str) -> Union[dict, str]:
     """
     Validate that the API has fabric token and the token is valid
-    @return returns the decoded claims
+    @return returns the decoded claims (with ``id_token`` key containing the raw token)
     """
     if token is not None:
         try:
-            token = token.replace('Bearer ', '')
+            raw_token = token.replace('Bearer ', '')
             LOG.info("Validating Fabric token")
             credmgr = OAuthCredMgr()
-            state, claims = credmgr.validate_token(token=token)
+            state, claims = credmgr.validate_token(token=raw_token)
 
             if state not in [str(TokenState.Valid), str(TokenState.Refreshed)]:
                 msg = f"Unable to validate provided token: {state} claims:{claims}"
                 LOG.error(msg)
                 return msg
+            # Include the raw id_token so downstream code can use it for
+            # Bearer-authenticated Core API calls (e.g. create_llm_key).
+            claims["id_token"] = raw_token
             return claims
         except Exception as e:
             msg = f"Unable to validate provided token e: {e}!"

--- a/fabric_cm/credmgr/swagger_server/response/decorators.py
+++ b/fabric_cm/credmgr/swagger_server/response/decorators.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from typing import Union
 
+import jwt as pyjwt
+
 from fabric_cm.credmgr.common.utils import Utils
 from fabric_cm.credmgr.core.oauth_credmgr import OAuthCredMgr, TokenState
 from fabric_cm.credmgr.swagger_server import jwt_validator
@@ -71,6 +73,7 @@ def vouch_authorize() -> Union[dict, None]:
     refresh_token = request.headers.get(VOUCH_REFRESH_TOKEN, None)
     cookie_name = CONFIG_OBJ.get_vouch_cookie_name()
     cookie = request.cookies.get(cookie_name)
+    from_cookie = False
     if ci_logon_id_token is None and refresh_token is None and cookie is not None:
         vouch_secret = CONFIG_OBJ.get_vouch_secret()
         vouch_compression = CONFIG_OBJ.is_vouch_cookie_compressed()
@@ -79,12 +82,24 @@ def vouch_authorize() -> Union[dict, None]:
         if status == ValidateCode.VALID:
             ci_logon_id_token = decoded_cookie.get('PIdToken')
             refresh_token = decoded_cookie.get('PRefreshToken')
+            from_cookie = True
 
     if ci_logon_id_token is not None and refresh_token is not None and cookie is not None:
-        code, claims_or_exception = jwt_validator.validate_jwt(token=ci_logon_id_token)
-        if code is not ValidateCode.VALID:
-            LOG.error(f"Unable to validate provided token: {code}/{claims_or_exception}")
-            return None
+        # When PIdToken comes from a vouch cookie we created, member_of was
+        # stripped to reduce cookie size, which invalidates the CILogon
+        # signature. The vouch cookie itself is integrity-protected, so we
+        # can safely decode without signature verification in that case.
+        if from_cookie:
+            try:
+                claims_or_exception = pyjwt.decode(ci_logon_id_token, options={"verify_signature": False})
+            except Exception as e:
+                LOG.error(f"Unable to decode token from cookie: {e}")
+                return None
+        else:
+            code, claims_or_exception = jwt_validator.validate_jwt(token=ci_logon_id_token)
+            if code is not ValidateCode.VALID:
+                LOG.error(f"Unable to validate provided token: {code}/{claims_or_exception}")
+                return None
 
         result = {OAuthCredMgr.REFRESH_TOKEN: refresh_token,
                   OAuthCredMgr.ID_TOKEN: ci_logon_id_token,

--- a/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
+++ b/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
@@ -611,13 +611,15 @@ fetch(CALLBACK_URL, {{ mode: 'no-cors' }})
         return cors_500(details=str(ex))
 
 
-@login_required
+@login_or_token_required
 def tokens_create_llm_post(key_name: str = None, comment: str = None,
                             duration: int = 30, models: str = None,
                             claims: dict = None):  # noqa: E501
     """Create an LLM token
 
     Request to create an LLM token for an user  # noqa: E501
+
+    Accepts either Vouch cookie auth (browser) or Bearer token auth (API/CLI).
 
     :param key_name: Human-readable name for the key
     :type key_name: str
@@ -638,7 +640,9 @@ def tokens_create_llm_post(key_name: str = None, comment: str = None,
         if models:
             models_list = [m.strip() for m in models.split(',') if m.strip()]
         credmgr = OAuthCredMgr()
-        result = credmgr.create_llm_key(cookie=claims.get(OAuthCredMgr.COOKIE),
+        cookie = claims.get(OAuthCredMgr.COOKIE)
+        token = claims.get("id_token") if not cookie else None
+        result = credmgr.create_llm_key(cookie=cookie, token=token,
                                          key_name=key_name, comment=comment,
                                          duration_days=duration, models=models_list)
         response_data = Status200OkNoContentData()

--- a/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
+++ b/fabric_cm/credmgr/swagger_server/response/tokens_controller.py
@@ -661,7 +661,7 @@ def tokens_create_llm_post(key_name: str = None, comment: str = None,
         return cors_500(details=str(ex))
 
 
-@login_required
+@login_or_token_required
 def tokens_delete_llm_delete(llm_key_id: str, claims: dict = None):  # noqa: E501
     """Delete an LLM token
 
@@ -677,9 +677,11 @@ def tokens_delete_llm_delete(llm_key_id: str, claims: dict = None):  # noqa: E50
     received_counter.labels(HTTP_METHOD_DELETE, TOKENS_DELETE_LLM_URL).inc()
     try:
         credmgr = OAuthCredMgr()
+        cookie = claims.get(OAuthCredMgr.COOKIE)
+        token = claims.get("id_token") if not cookie else None
         credmgr.delete_llm_key(llm_key_id=llm_key_id,
                                     user_email=claims.get(OAuthCredMgr.EMAIL),
-                                    cookie=claims.get(OAuthCredMgr.COOKIE))
+                                    cookie=cookie, token=token)
         response_data = Status200OkNoContentData()
         response_data.details = f"LLM token {llm_key_id} has been successfully deleted"
         response = Status200OkNoContent()
@@ -696,7 +698,7 @@ def tokens_delete_llm_delete(llm_key_id: str, claims: dict = None):  # noqa: E50
         return cors_500(details=str(ex))
 
 
-@login_required
+@login_or_token_required
 def tokens_llm_keys_get(limit: int = 200, offset: int = 0,
                          claims: dict = None):  # noqa: E501
     """Get LLM tokens for a user
@@ -715,7 +717,9 @@ def tokens_llm_keys_get(limit: int = 200, offset: int = 0,
     received_counter.labels(HTTP_METHOD_GET, TOKENS_LLM_KEYS_URL).inc()
     try:
         credmgr = OAuthCredMgr()
-        keys = credmgr.get_llm_keys(cookie=claims.get(OAuthCredMgr.COOKIE),
+        cookie = claims.get(OAuthCredMgr.COOKIE)
+        token = claims.get("id_token") if not cookie else None
+        keys = credmgr.get_llm_keys(cookie=cookie, token=token,
                                          offset=offset, limit=limit)
         response_data = Status200OkNoContentData()
         response_data.details = keys
@@ -733,7 +737,7 @@ def tokens_llm_keys_get(limit: int = 200, offset: int = 0,
         return cors_500(details=str(ex))
 
 
-@login_required
+@login_or_token_required
 def tokens_llm_models_get(claims: dict = None):  # noqa: E501
     """Get available LLM models
 


### PR DESCRIPTION
## Summary
- Chunk vouch cookies to match vouch-proxy format (4000-byte chunks) for Core API requests
- Strip `member_of` claim from CILogon id_token and decoded claims before creating vouch cookies, reducing cookie size significantly for users with many group memberships (50+ groups = ~1850 bytes)
- When token is extracted from the vouch cookie, decode without CILogon signature verification since the vouch cookie itself is integrity-protected
- Add Bearer token auth support for LLM key endpoints (create, delete, list, models)
- Enforce max 10 active LLM keys per user
- Fix credential page frontend handling

## Test plan
- [x] Verify vouch cookie creation works for users with many group memberships (member_of with 50+ groups)
- [x] Verify cookie-based token creation still works end-to-end through the browser flow
- [x] Verify API-based token creation (Bearer auth) still validates CILogon signature
- [x] Verify LLM key endpoints work with both cookie auth and Bearer token auth
- [x] Verify cookie chunking works correctly for Core API calls