### PR TITLE
Increase Core API project query limit to 200 and fix pagination

### DIFF
--- a/fabric_cm/credmgr/external_apis/core_api.py
+++ b/fabric_cm/credmgr/external_apis/core_api.py
@@ -155,7 +155,7 @@ class CoreApi:
 
     def __get_user_projects(self, *, project_name: str = None):
         offset = 0
-        limit = 50
+        limit = 200
         uuid, email = self.get_user_id_and_email()
         result = []
         total_fetched = 0
@@ -187,8 +187,7 @@ class CoreApi:
 
             if total_fetched == total:
                 break
-            offset = size
-            limit += limit
+            offset += size
 
         return result
 


### PR DESCRIPTION
## Summary
- Increase the default `limit` for Core API project queries from 50 to 200 to fetch all projects in fewer requests.
- Fix pagination bug: previously the code doubled the `limit` on each iteration (`limit += limit`) instead of advancing the `offset`. Now correctly uses `offset += size` to paginate through results.

## Test plan
- [x] Verify users with many projects (>50) get all projects returned correctly
- [x] Verify pagination still works for users with >200 projects